### PR TITLE
Store expires_at as UTCDatetime object

### DIFF
--- a/src/Bridge/AccessTokenRepository.php
+++ b/src/Bridge/AccessTokenRepository.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Passport\Bridge;
 
-use DateTime;
+use MongoDB\BSON\UTCDateTime;
 use Laravel\Passport\TokenRepository;
 use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Passport\Events\AccessTokenCreated;
@@ -59,9 +59,9 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
             'client_id' => $accessTokenEntity->getClient()->getIdentifier(),
             'scopes' => $this->scopesToArray($accessTokenEntity->getScopes()),
             'revoked' => false,
-            'created_at' => new DateTime,
-            'updated_at' => new DateTime,
-            'expires_at' => $accessTokenEntity->getExpiryDateTime(),
+            'created_at' => new UTCDateTime,
+            'updated_at' => new UTCDateTime,
+            'expires_at' => new UTCDateTime($accessTokenEntity->getExpiryDateTime()),
         ]);
 
         $this->events->dispatch(new AccessTokenCreated(

--- a/src/Bridge/AuthCodeRepository.php
+++ b/src/Bridge/AuthCodeRepository.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Passport\Bridge;
 
+use MongoDB\BSON\UTCDateTime;
 use Laravel\Passport\AuthCode as AuthCodeModel;
 use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
 use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;

--- a/src/Bridge/AuthCodeRepository.php
+++ b/src/Bridge/AuthCodeRepository.php
@@ -32,7 +32,7 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
                 'client_id' => $authCodeEntity->getClient()->getIdentifier(),
                 'scopes' => $this->formatScopesForStorage($authCodeEntity->getScopes()),
                 'revoked' => false,
-                'expires_at' => $authCodeEntity->getExpiryDateTime(),
+                'expires_at' => new UTCDateTime($authCodeEntity->getExpiryDateTime()),
             ]
         );
 

--- a/src/Bridge/RefreshTokenRepository.php
+++ b/src/Bridge/RefreshTokenRepository.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Passport\Bridge;
 
+use MongoDB\BSON\UTCDateTime;
 use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Passport\Events\RefreshTokenCreated;
 use Laravel\Passport\RefreshToken as RefreshTokenModel;

--- a/src/Bridge/RefreshTokenRepository.php
+++ b/src/Bridge/RefreshTokenRepository.php
@@ -59,7 +59,7 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
                 '_id' => $id = $refreshTokenEntity->getIdentifier(),
                 'access_token_id' => $accessTokenId = $refreshTokenEntity->getAccessToken()->getIdentifier(),
                 'revoked' => false,
-                'expires_at' => $refreshTokenEntity->getExpiryDateTime(),
+                'expires_at' => new UTCDateTime($refreshTokenEntity->getExpiryDateTime()),
             ]
         );
 

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -74,7 +74,7 @@ class TokenRepository
         return $client->tokens(
             [
                 'user_id' => (string) $user->getKey(),
-                'revoked' => 0,
+                'revoked' => false,
                 'expires_at' => ['$gt' => new UTCDateTime()],
             ]
         )
@@ -140,7 +140,7 @@ class TokenRepository
         return $client->tokens(
             [
                 'user_id' => (string) $user->getKey(),
-                'revoked' => 0,
+                'revoked' => false,
                 'expires_at' => ['$gt' => new UTCDateTime()],
             ]
         )

--- a/tests/BridgeAccessTokenRepositoryTest.php
+++ b/tests/BridgeAccessTokenRepositoryTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Carbon\Carbon;
+use MongoDB\BSON\UTCDateTime;
 
 class BridgeAccessTokenRepositoryTest extends PHPUnit_Framework_TestCase
 {
@@ -23,9 +24,10 @@ class BridgeAccessTokenRepositoryTest extends PHPUnit_Framework_TestCase
             $this->assertEquals('client-id', $array['client_id']);
             $this->assertEquals(['scopes'], $array['scopes']);
             $this->assertEquals(false, $array['revoked']);
-            $this->assertInstanceOf('DateTime', $array['created_at']);
-            $this->assertInstanceOf('DateTime', $array['updated_at']);
-            $this->assertEquals($expiration, $array['expires_at']);
+            $this->assertInstanceOf(UTCDateTime::class, $array['created_at']);
+            $this->assertInstanceOf(UTCDateTime::class, $array['updated_at']);
+            $this->assertInstanceOf(UTCDateTime::class, $array['expires_at']);
+            $this->assertEquals(new UTCDateTime($expiration), $array['expires_at']);
         });
 
         $events->shouldReceive('dispatch')->once();


### PR DESCRIPTION
The field expires_at is being stored as an array instead of UTCDateTime object:
```
Array
(
    [_id] => a72dd25658ce5a272024fc393665abceeaa270a6afa51186411074d30fb6a1acde00072ca34c04da
    [user_id] => 5988d8bd58b08d4a5d26dc83
    [client_id] => 599f1fa4e8ddff00017a8762
    [scopes] => Array
        (
            [0] => read.profile
        )

    [revoked] => 
    [created_at] => MongoDB\BSON\UTCDateTime Object
        (
            [milliseconds] => 1503600570055
        )

    [updated_at] => MongoDB\BSON\UTCDateTime Object
        (
            [milliseconds] => 1503600570055
        )

    [expires_at] => Array
        (
            [date] => 2017-09-08 15:49:30.000000
            [timezone_type] => 3
            [timezone] => America/Sao_Paulo
        )

)
```

The goal of this PR is to solve this problem.