### PR TITLE
Validate client scopes

### DIFF
--- a/src/Bridge/Client.php
+++ b/src/Bridge/Client.php
@@ -35,6 +35,8 @@ class Client implements ScopedClientInterface
 
     /**
      * Get the client's allowed scopes.
+     * If this is empty, the client will be able to request
+     * all scopes (no restriction).
      *
      * @return array
      */
@@ -46,6 +48,8 @@ class Client implements ScopedClientInterface
     /**
      * Set allowed scopes attributes converting optional
      * param $allowedScopes to array.
+     * If the client has no allowed scopes defined or the string '*',
+     * it means the client has no scope restrictions.
      *
      * @param mixed $allowedScopes
      */

--- a/src/Bridge/Client.php
+++ b/src/Bridge/Client.php
@@ -66,6 +66,6 @@ class Client implements ScopedClientInterface
             $this->allowedScopes = explode(',', trim($allowedScopes));
         }
 
-        array_walk($this->allowedScopes, 'trim');
+        $this->allowedScopes = array_map('trim', $this->allowedScopes);
     }
 }

--- a/src/Bridge/Client.php
+++ b/src/Bridge/Client.php
@@ -35,8 +35,9 @@ class Client implements ScopedClientInterface
 
     /**
      * Get the client's allowed scopes.
-     * If this is empty, the client will be able to request
-     * all scopes (no restriction).
+     * This can be an empty array in cases where the client
+     * can not request any scope, an array of specific scopes
+     * or a wild card '*'.
      *
      * @return array
      */
@@ -48,14 +49,12 @@ class Client implements ScopedClientInterface
     /**
      * Set allowed scopes attributes converting optional
      * param $allowedScopes to array.
-     * When the client has no scopes restrictions, an empty array is
-     * set, every scope requested will be allowed.
      *
      * @param mixed $allowedScopes
      */
     protected function setAllowedScopes($allowedScopes = null)
     {
-        if (!$this->hasScopeRestrictions($allowedScopes)) {
+        if (empty($allowedScopes)) {
             $this->allowedScopes = [];
 
             return;
@@ -68,20 +67,5 @@ class Client implements ScopedClientInterface
         }
 
         array_walk($this->allowedScopes, 'trim');
-    }
-
-    /**
-     * If the client has no allowed scopes defined or the string '*',
-     * it means the client has no scope restrictions.
-     * Allowing all scopes for a client that has no allowed scopes definied
-     * is intended to maintain compatibility with the original behavior.
-     *
-     * @param mixed $allowedScopes
-     *
-     * @return bool
-     */
-    protected function hasScopeRestrictions($allowedScopes = null)
-    {
-        return !empty($allowedScopes) && '*' !== $allowedScopes;
     }
 }

--- a/src/Bridge/Client.php
+++ b/src/Bridge/Client.php
@@ -53,9 +53,9 @@ class Client implements ScopedClientInterface
      *
      * @param mixed $allowedScopes
      */
-    protected function setAllowedScopes($allowedScopes = nul)
+    protected function setAllowedScopes($allowedScopes = null)
     {
-        if (!$allowedScopes) {
+        if (!$allowedScopes || '*' === $allowedScopes) {
             $this->allowedScopes = [];
 
             return;

--- a/src/Bridge/Client.php
+++ b/src/Bridge/Client.php
@@ -48,14 +48,14 @@ class Client implements ScopedClientInterface
     /**
      * Set allowed scopes attributes converting optional
      * param $allowedScopes to array.
-     * If the client has no allowed scopes defined or the string '*',
-     * it means the client has no scope restrictions.
+     * When the client has no scopes restrictions, an empty array is
+     * set, every scope requested will be allowed.
      *
      * @param mixed $allowedScopes
      */
     protected function setAllowedScopes($allowedScopes = null)
     {
-        if (!$allowedScopes || '*' === $allowedScopes) {
+        if (!$this->hasScopeRestrictions($allowedScopes)) {
             $this->allowedScopes = [];
 
             return;
@@ -68,5 +68,20 @@ class Client implements ScopedClientInterface
         }
 
         array_walk($this->allowedScopes, 'trim');
+    }
+
+    /**
+     * If the client has no allowed scopes defined or the string '*',
+     * it means the client has no scope restrictions.
+     * Allowing all scopes for a client that has no allowed scopes definied
+     * is intended to maintain compatibility with the original behavior.
+     *
+     * @param mixed $allowedScopes
+     *
+     * @return bool
+     */
+    protected function hasScopeRestrictions($allowedScopes = null)
+    {
+        return !empty($allowedScopes) && '*' !== $allowedScopes;
     }
 }

--- a/src/Bridge/Client.php
+++ b/src/Bridge/Client.php
@@ -2,27 +2,67 @@
 
 namespace Laravel\Passport\Bridge;
 
+use Laravel\Passport\Bridge\ScopedClientInterface;
 use League\OAuth2\Server\Entities\Traits\ClientTrait;
 use League\OAuth2\Server\Entities\Traits\EntityTrait;
-use League\OAuth2\Server\Entities\ClientEntityInterface;
 
-class Client implements ClientEntityInterface
+class Client implements ScopedClientInterface
 {
     use ClientTrait, EntityTrait;
 
     /**
+     * @var string[]
+     */
+    protected $allowedScopes;
+
+    /**
      * Create a new client instance.
      *
-     * @param  string  $identifier
-     * @param  string  $name
-     * @param  string  $redirectUri
+     * @param  string $identifier
+     * @param  string $name
+     * @param  string $redirectUri
+     * @param  mixed  $allowedScopes
      * @return void
      */
-    public function __construct($identifier, $name, $redirectUri)
+    public function __construct($identifier, $name, $redirectUri, $allowedScopes = null)
     {
         $this->setIdentifier($identifier);
+        $this->setAllowedScopes($allowedScopes);
 
         $this->name = $name;
         $this->redirectUri = explode(',', $redirectUri);
+    }
+
+    /**
+     * Get the client's allowed scopes.
+     *
+     * @return array
+     */
+    public function getAllowedScopes()
+    {
+        return array_filter($this->allowedScopes);
+    }
+
+    /**
+     * Set allowed scopes attributes converting optional
+     * param $allowedScopes to array.
+     *
+     * @param mixed $allowedScopes
+     */
+    protected function setAllowedScopes($allowedScopes = nul)
+    {
+        if (!$allowedScopes) {
+            $this->allowedScopes = [];
+
+            return;
+        }
+
+        if (is_array($allowedScopes)) {
+            $this->allowedScopes = $allowedScopes;
+        } elseif(is_string($allowedScopes)) {
+            $this->allowedScopes = explode(',', trim($allowedScopes));
+        }
+
+        array_walk($this->allowedScopes, 'trim');
     }
 }

--- a/src/Bridge/ClientRepository.php
+++ b/src/Bridge/ClientRepository.php
@@ -44,7 +44,7 @@ class ClientRepository implements ClientRepositoryInterface
         // and verify the secret if necessary. If the secret is valid we will be ready to
         // return this client instance back out to the consuming methods and finish up.
         $client = new Client(
-            $clientIdentifier, $record->name, $record->redirect
+            $clientIdentifier, $record->name, $record->redirect, $record->allowed_scopes
         );
 
         if ($mustValidateSecret &&

--- a/src/Bridge/ScopeRepository.php
+++ b/src/Bridge/ScopeRepository.php
@@ -51,7 +51,7 @@ class ScopeRepository implements ScopeRepositoryInterface
      *
      * @return bool
      */
-    protected function validateClientScopes(
+    public function validateClientScopes(
         array $scopes,
         $grantType,
         ClientEntityInterface $clientEntity

--- a/src/Bridge/ScopeRepository.php
+++ b/src/Bridge/ScopeRepository.php
@@ -26,7 +26,7 @@ class ScopeRepository implements ScopeRepositoryInterface
         array $scopes, $grantType,
         ClientEntityInterface $clientEntity, $userIdentifier = null)
     {
-        $this->validateClientScopes($scopes, $grantType, $clientEntity);
+        $this->validateClientScopes($scopes, $clientEntity);
 
         if (! in_array($grantType, ['password', 'personal_access'])) {
             $scopes = collect($scopes)->reject(function ($scope) {
@@ -46,14 +46,12 @@ class ScopeRepository implements ScopeRepositoryInterface
      * @throws OAuthServerException
      *
      * @param array                 $scopes
-     * @param                       $grantType
      * @param ClientEntityInterface $clientEntity
      *
      * @return bool
      */
     public function validateClientScopes(
         array $scopes,
-        $grantType,
         ClientEntityInterface $clientEntity
     ) {
         if (!$clientAllowedScopes = $clientEntity->getAllowedScopes()) {

--- a/src/Bridge/ScopeRepository.php
+++ b/src/Bridge/ScopeRepository.php
@@ -54,7 +54,9 @@ class ScopeRepository implements ScopeRepositoryInterface
         array $scopes,
         ClientEntityInterface $clientEntity
     ) {
-        if (!$clientAllowedScopes = $clientEntity->getAllowedScopes()) {
+        $clientAllowedScopes = $clientEntity->getAllowedScopes();
+
+        if (in_array('*', $clientAllowedScopes)) {
             return true;
         }
 

--- a/src/Bridge/ScopedClientInterface.php
+++ b/src/Bridge/ScopedClientInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Laravel\Passport\Bridge;
+
+use League\OAuth2\Server\Entities\ClientEntityInterface;
+
+interface ScopedClientInterface extends ClientEntityInterface
+{
+    /**
+     * Get the client's allowed scopes.
+     *
+     * @return array
+     */
+    public function getAllowedScopes();
+}

--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -101,10 +101,11 @@ class ClientRepository
      * @param  string $redirect
      * @param  bool   $personalAccess
      * @param  bool   $password
+     * @param  string $allowedScopes
      *
      * @return \Laravel\Passport\Client
      */
-    public function create($userId, $name, $redirect, $personalAccess = false, $password = false)
+    public function create($userId, $name, $redirect, $personalAccess = false, $password = false, $allowedScopes = null)
     {
         $client = new Client();
 
@@ -117,6 +118,7 @@ class ClientRepository
                 'personal_access_client' => $personalAccess,
                 'password_client' => $password,
                 'revoked' => false,
+                'allowed_scopes' => $allowedScopes,
             ],
             true
         );

--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -120,7 +120,7 @@ class ClientCommand extends Command
         do {
             $allowedScopes = $this->ask(
                 'Which scopes does the client need? Valid options: all / none / [comma separated scopes]',
-                'all'
+                'none'
             );
         } while (false === $allowedScopes = $this->parseAllowedScopes($allowedScopes));
 

--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -113,12 +113,32 @@ class ClientCommand extends Command
             url('/auth/callback')
         );
 
+        $allowedScopes = $this->ask(
+            'Which scopes does the client need? Available: '.$this->getAvailableScopes()
+        );
+
         $client = $clients->create(
-            $userId, $name, $redirect
+            $userId, $name, $redirect, false, false, $allowedScopes
         );
 
         $this->info('New client created successfully.');
         $this->line('<comment>Client ID:</comment> '.$client->_id);
         $this->line('<comment>Client secret:</comment> '.$client->secret);
+    }
+
+    /**
+     * Get available scopes keys as string.
+     *
+     * @return string
+     */
+    protected function getAvailableScopes()
+    {
+        $scopes = [];
+
+        foreach (Passport::scopes() as $scope) {
+            $scopes[] = $scope->id;
+        }
+
+        return implode(',', $scopes);
     }
 }

--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -115,7 +115,8 @@ class ClientCommand extends Command
         );
 
         $allowedScopes = $this->ask(
-            'Which scopes does the client need? Available: '.$this->getAvailableScopes()
+            'Which scopes does the client need? Available: '.$this->getAvailableScopes(),
+            '*'
         );
 
         $client = $clients->create(

--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Passport\Console;
 
+use Laravel\Passport\Passport;
 use Illuminate\Console\Command;
 use Laravel\Passport\ClientRepository;
 use Laravel\Passport\PersonalAccessClient;

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -73,7 +73,6 @@ class AuthorizationController
 
             $scopeRepository->validateClientScopes(
                 $authRequest->getScopes(),
-                $authRequest->getGrantTypeId(),
                 $authRequest->getClient()
             );
 

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -8,6 +8,7 @@ use Laravel\Passport\Bridge\User;
 use Laravel\Passport\TokenRepository;
 use Laravel\Passport\ClientRepository;
 use MongolidLaravel\MongolidModel as Model;
+use Laravel\Passport\Bridge\ScopeRepository;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Response as Psr7Response;
 use League\OAuth2\Server\AuthorizationServer;
@@ -57,9 +58,10 @@ class AuthorizationController
     public function authorize(ServerRequestInterface $psrRequest,
                               Request $request,
                               ClientRepository $clients,
-                              TokenRepository $tokens)
+                              TokenRepository $tokens,
+                              ScopeRepository $scopeRepository)
     {
-        return $this->withErrorHandling(function () use ($psrRequest, $request, $clients, $tokens) {
+        return $this->withErrorHandling(function () use ($psrRequest, $request, $clients, $tokens, $scopeRepository) {
             $authRequest = $this->server->validateAuthorizationRequest($psrRequest);
 
             $scopes = $this->parseScopes($authRequest);
@@ -67,6 +69,12 @@ class AuthorizationController
             $token = $tokens->findValidToken(
                 $user = $request->user(),
                 $client = $clients->find($authRequest->getClient()->getIdentifier())
+            );
+
+            $scopeRepository->validateClientScopes(
+                $authRequest->getScopes(),
+                $authRequest->getGrantTypeId(),
+                $authRequest->getClient()
             );
 
             if ($token && $token->scopes === collect($scopes)->pluck('id')->all()) {

--- a/src/Http/Controllers/HandlesOAuthErrors.php
+++ b/src/Http/Controllers/HandlesOAuthErrors.php
@@ -27,10 +27,9 @@ trait HandlesOAuthErrors
             return $callback();
         } catch (OAuthServerException $e) {
             $this->exceptionHandler()->report($e);
-            $psr7Response = $e->generateHttpResponse(new Psr7Response);
 
             return $this->convertResponse(
-                $e->generateHttpResponse(new Psr7Response)
+                $e->generateHttpResponse(new Psr7Response)->withoutHeader('WWW-Authenticate')
             );
         } catch (Exception $e) {
             $this->exceptionHandler()->report($e);

--- a/tests/AuthorizationControllerTest.php
+++ b/tests/AuthorizationControllerTest.php
@@ -32,7 +32,7 @@ class AuthorizationControllerTest extends PHPUnit_Framework_TestCase
         $request->shouldReceive('user')->andReturn('user');
 
         $authRequest->shouldReceive('getClient')->andReturn($clientEntity = Mockery::mock(ClientEntityInterface::class));
-        $authRequest->shouldReceive('getScopes')->andReturn([new Laravel\Passport\Bridge\Scope('scope-1')]);
+        $authRequest->shouldReceive('getScopes')->andReturn($scopes = [new Laravel\Passport\Bridge\Scope('scope-1')]);
         $authRequest->shouldReceive('getGrantTypeId')->andReturn('authorization_code');
 
         $clientEntity->shouldReceive('getIdentifier')->andReturn(1);
@@ -53,7 +53,7 @@ class AuthorizationControllerTest extends PHPUnit_Framework_TestCase
         $tokens->shouldReceive('findValidToken')->with('user', 'client')->andReturnNull();
 
         $scopeRepository = Mockery::mock('Laravel\Passport\Bridge\ScopeRepository');
-        $scopeRepository->shouldReceive('validateClientScopes')->withAnyArgs()->andReturn(true);
+        $scopeRepository->shouldReceive('validateClientScopes')->with($scopes, $clientEntity)->andReturn(true);
 
         $this->assertEquals('view', $controller->authorize(
             Mockery::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients, $tokens, $scopeRepository
@@ -110,7 +110,7 @@ class AuthorizationControllerTest extends PHPUnit_Framework_TestCase
         $request->shouldNotReceive('session');
 
         $authRequest->shouldReceive('getClient')->andReturn($clientEntity = Mockery::mock(ClientEntityInterface::class));
-        $authRequest->shouldReceive('getScopes')->twice()->andReturn([new Laravel\Passport\Bridge\Scope('scope-1')]);
+        $authRequest->shouldReceive('getScopes')->twice()->andReturn($scopes = [new Laravel\Passport\Bridge\Scope('scope-1')]);
         $authRequest->shouldReceive('setUser')->once()->andReturnNull();
         $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(true);
         $authRequest->shouldReceive('getGrantTypeId')->andReturn('authorization_code');
@@ -125,7 +125,7 @@ class AuthorizationControllerTest extends PHPUnit_Framework_TestCase
         $token->shouldReceive('getAttribute')->with('scopes')->andReturn(['scope-1']);
 
         $scopeRepository = Mockery::mock('Laravel\Passport\Bridge\ScopeRepository');
-        $scopeRepository->shouldReceive('validateClientScopes')->withAnyArgs()->andReturn(true);
+        $scopeRepository->shouldReceive('validateClientScopes')->with($scopes, $clientEntity)->andReturn(true);
 
         $this->assertEquals('approved', $controller->authorize(
             Mockery::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients, $tokens, $scopeRepository

--- a/tests/AuthorizationControllerTest.php
+++ b/tests/AuthorizationControllerTest.php
@@ -4,6 +4,7 @@ use Illuminate\Container\Container;
 use League\OAuth2\Server\AuthorizationServer;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Routing\ResponseFactory;
+use League\OAuth2\Server\Entities\ClientEntityInterface;
 
 class AuthorizationControllerTest extends PHPUnit_Framework_TestCase
 {
@@ -30,8 +31,11 @@ class AuthorizationControllerTest extends PHPUnit_Framework_TestCase
         $session->shouldReceive('put')->with('authRequest', $authRequest);
         $request->shouldReceive('user')->andReturn('user');
 
-        $authRequest->shouldReceive('getClient->getIdentifier')->andReturn(1);
+        $authRequest->shouldReceive('getClient')->andReturn($clientEntity = Mockery::mock(ClientEntityInterface::class));
         $authRequest->shouldReceive('getScopes')->andReturn([new Laravel\Passport\Bridge\Scope('scope-1')]);
+        $authRequest->shouldReceive('getGrantTypeId')->andReturn('authorization_code');
+
+        $clientEntity->shouldReceive('getIdentifier')->andReturn(1);
 
         $response->shouldReceive('view')->once()->andReturnUsing(function ($view, $data) use ($authRequest) {
             $this->assertEquals('passport::authorize', $view);
@@ -48,8 +52,11 @@ class AuthorizationControllerTest extends PHPUnit_Framework_TestCase
         $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
         $tokens->shouldReceive('findValidToken')->with('user', 'client')->andReturnNull();
 
+        $scopeRepository = Mockery::mock('Laravel\Passport\Bridge\ScopeRepository');
+        $scopeRepository->shouldReceive('validateClientScopes')->withAnyArgs()->andReturn(true);
+
         $this->assertEquals('view', $controller->authorize(
-            Mockery::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients, $tokens
+            Mockery::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients, $tokens, $scopeRepository
         ));
     }
 
@@ -72,8 +79,10 @@ class AuthorizationControllerTest extends PHPUnit_Framework_TestCase
 
         $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
 
+        $scopeRepository = Mockery::mock('Laravel\Passport\Bridge\ScopeRepository');
+
         $this->assertEquals('whoops', $controller->authorize(
-            Mockery::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients, $tokens
+            Mockery::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients, $tokens, $scopeRepository
         )->getContent());
     }
 
@@ -100,10 +109,13 @@ class AuthorizationControllerTest extends PHPUnit_Framework_TestCase
         $user->shouldReceive('getKey')->andReturn(1);
         $request->shouldNotReceive('session');
 
-        $authRequest->shouldReceive('getClient->getIdentifier')->once()->andReturn(1);
-        $authRequest->shouldReceive('getScopes')->once()->andReturn([new Laravel\Passport\Bridge\Scope('scope-1')]);
+        $authRequest->shouldReceive('getClient')->andReturn($clientEntity = Mockery::mock(ClientEntityInterface::class));
+        $authRequest->shouldReceive('getScopes')->twice()->andReturn([new Laravel\Passport\Bridge\Scope('scope-1')]);
         $authRequest->shouldReceive('setUser')->once()->andReturnNull();
         $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(true);
+        $authRequest->shouldReceive('getGrantTypeId')->andReturn('authorization_code');
+
+        $clientEntity->shouldReceive('getIdentifier')->andReturn(1);
 
         $clients = Mockery::mock('Laravel\Passport\ClientRepository');
         $clients->shouldReceive('find')->with(1)->andReturn('client');
@@ -112,8 +124,11 @@ class AuthorizationControllerTest extends PHPUnit_Framework_TestCase
         $tokens->shouldReceive('findValidToken')->with($user, 'client')->andReturn($token = Mockery::mock('Laravel\Passport\Token'));
         $token->shouldReceive('getAttribute')->with('scopes')->andReturn(['scope-1']);
 
+        $scopeRepository = Mockery::mock('Laravel\Passport\Bridge\ScopeRepository');
+        $scopeRepository->shouldReceive('validateClientScopes')->withAnyArgs()->andReturn(true);
+
         $this->assertEquals('approved', $controller->authorize(
-            Mockery::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients, $tokens
+            Mockery::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients, $tokens, $scopeRepository
         )->getContent());
     }
 }

--- a/tests/BridgeClientRepositoryTest.php
+++ b/tests/BridgeClientRepositoryTest.php
@@ -71,7 +71,7 @@ class BridgeClientRepositoryTest extends PHPUnit_Framework_TestCase
 
         $client = $repository->getClientEntity(1, 'client_credentials', 'secret', true);
 
-        $this->assertSame([], $client->getAllowedScopes());
+        $this->assertSame(['*'], $client->getAllowedScopes());
     }
 }
 

--- a/tests/BridgeClientRepositoryTest.php
+++ b/tests/BridgeClientRepositoryTest.php
@@ -34,6 +34,32 @@ class BridgeClientRepositoryTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Laravel\Passport\Bridge\Client', $repository->getClientEntity(1, 'client_credentials', 'secret', true));
         $this->assertNull($repository->getClientEntity(1, 'authorization_code', 'secret', true));
     }
+
+    public function test_should_get_client_with_allowed_scopes()
+    {
+        $clients = Mockery::mock('Laravel\Passport\ClientRepository');
+        $client = new BridgeClientRepositoryTestClientStub;
+        $client->allowed_scopes = 'foo,bar';
+        $clients->shouldReceive('findActive')->with(1)->andReturn($client);
+        $repository = new ClientRepository($clients);
+
+        $client = $repository->getClientEntity(1, 'client_credentials', 'secret', true);
+
+        $this->assertSame(['foo', 'bar'], $client->getAllowedScopes());
+    }
+
+    public function test_should_get_client_with_allowed_scopes_as_array()
+    {
+        $clients = Mockery::mock('Laravel\Passport\ClientRepository');
+        $client = new BridgeClientRepositoryTestClientStub;
+        $client->allowed_scopes = ['foo', 'bar'];
+        $clients->shouldReceive('findActive')->with(1)->andReturn($client);
+        $repository = new ClientRepository($clients);
+
+        $client = $repository->getClientEntity(1, 'client_credentials', 'secret', true);
+
+        $this->assertSame(['foo', 'bar'], $client->getAllowedScopes());
+    }
 }
 
 class BridgeClientRepositoryTestClientStub
@@ -43,6 +69,7 @@ class BridgeClientRepositoryTestClientStub
     public $secret = 'secret';
     public $personal_access_client = false;
     public $password_client = false;
+    public $allowed_scopes = null;
     public function firstParty()
     {
         return $this->personal_access_client || $this->password_client;

--- a/tests/BridgeClientRepositoryTest.php
+++ b/tests/BridgeClientRepositoryTest.php
@@ -60,6 +60,19 @@ class BridgeClientRepositoryTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame(['foo', 'bar'], $client->getAllowedScopes());
     }
+
+    public function test_should_restrict_scopes_for_client_with_wild_card()
+    {
+        $clients = Mockery::mock('Laravel\Passport\ClientRepository');
+        $client = new BridgeClientRepositoryTestClientStub;
+        $client->allowed_scopes = '*';
+        $clients->shouldReceive('findActive')->with(1)->andReturn($client);
+        $repository = new ClientRepository($clients);
+
+        $client = $repository->getClientEntity(1, 'client_credentials', 'secret', true);
+
+        $this->assertSame([], $client->getAllowedScopes());
+    }
 }
 
 class BridgeClientRepositoryTestClientStub

--- a/tests/BridgeScopeRepositoryTest.php
+++ b/tests/BridgeScopeRepositoryTest.php
@@ -16,7 +16,7 @@ class BridgeScopeRepositoryTest extends PHPUnit_Framework_TestCase
         $repository = new ScopeRepository;
 
         $scopes = $repository->finalizeScopes(
-            [$scope1 = new Scope('scope-1'), new Scope('scope-2')], 'client_credentials', new Client('id', 'name', 'http://localhost'), 1
+            [$scope1 = new Scope('scope-1'), new Scope('scope-2')], 'client_credentials', new Client('id', 'name', 'http://localhost', '*'), 1
         );
 
         $this->assertEquals([$scope1], $scopes);
@@ -31,7 +31,7 @@ class BridgeScopeRepositoryTest extends PHPUnit_Framework_TestCase
         $repository = new ScopeRepository;
 
         $scopes = $repository->finalizeScopes(
-            [$scope1 = new Scope('*')], 'client_credentials', new Client('id', 'name', 'http://localhost'), 1
+            [$scope1 = new Scope('*')], 'client_credentials', new Client('id', 'name', 'http://localhost', '*'), 1
         );
 
         $this->assertEquals([], $scopes);
@@ -55,6 +55,24 @@ class BridgeScopeRepositoryTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($rawScopes, $scopes);
     }
 
+    public function test_validate_client_allowed_scopes_for_a_client_with_no_scope_restriction()
+    {
+        Passport::tokensCan([
+            'scope-1' => 'description',
+            'scope-2' => 'description',
+        ]);
+
+        $repository = new ScopeRepository;
+
+        $rawScopes = [new Scope('scope-1'), new Scope('scope-2')];
+
+        $scopes = $repository->finalizeScopes(
+            $rawScopes, 'client_credentials', new Client('id', 'name', 'http://localhost', '*'), 1
+        );
+
+        $this->assertEquals($rawScopes, $scopes);
+    }
+
     /**
      * @expectedException League\OAuth2\Server\Exception\OAuthServerException
      */
@@ -68,6 +86,22 @@ class BridgeScopeRepositoryTest extends PHPUnit_Framework_TestCase
 
         $scopes = $repository->finalizeScopes(
             [new Scope('scope-1')], 'client_credentials', new Client('id', 'name', 'http://localhost', 'scope-2,scope-3'), 1
+        );
+    }
+
+    /**
+     * @expectedException League\OAuth2\Server\Exception\OAuthServerException
+     */
+    public function test_validate_client_allowed_scopes_should_throw_exception_for_a_client_with_no_allowed_scope()
+    {
+        Passport::tokensCan([
+            'scope-1' => 'description',
+        ]);
+
+        $repository = new ScopeRepository;
+
+        $scopes = $repository->finalizeScopes(
+            [new Scope('scope-1')], 'client_credentials', new Client('id', 'name', 'http://localhost'), 1
         );
     }
 }

--- a/tests/BridgeScopeRepositoryTest.php
+++ b/tests/BridgeScopeRepositoryTest.php
@@ -36,4 +36,38 @@ class BridgeScopeRepositoryTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals([], $scopes);
     }
+
+    public function test_validate_client_allowed_scopes()
+    {
+        Passport::tokensCan([
+            'scope-1' => 'description',
+            'scope-2' => 'description',
+        ]);
+
+        $repository = new ScopeRepository;
+
+        $rawScopes = [new Scope('scope-1'), new Scope('scope-2')];
+
+        $scopes = $repository->finalizeScopes(
+            $rawScopes, 'client_credentials', new Client('id', 'name', 'http://localhost', 'scope-1,scope-2'), 1
+        );
+
+        $this->assertEquals($rawScopes, $scopes);
+    }
+
+    /**
+     * @expectedException League\OAuth2\Server\Exception\OAuthServerException
+     */
+    public function test_validate_client_allowed_scopes_should_throw_exception()
+    {
+        Passport::tokensCan([
+            'scope-1' => 'description',
+        ]);
+
+        $repository = new ScopeRepository;
+
+        $scopes = $repository->finalizeScopes(
+            [new Scope('scope-1')], 'client_credentials', new Client('id', 'name', 'http://localhost', 'scope-2,scope-3'), 1
+        );
+    }
 }


### PR DESCRIPTION
This is a modification of passport default behavior.
With this change, we add the ability of limiting the scopes that a client (application) can request.