### PR TITLE
Add middleware CheckClientCredentialsForAnyScope

### DIFF
--- a/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
+++ b/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Laravel\Passport\Http\Middleware;
+
+use Closure;
+use League\OAuth2\Server\ResourceServer;
+use Illuminate\Auth\AuthenticationException;
+use Laravel\Passport\Exceptions\MissingScopeException;
+use League\OAuth2\Server\Exception\OAuthServerException;
+use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
+
+class CheckClientCredentialsForAnyScope
+{
+    /**
+     * The Resource Server instance.
+     *
+     * @var \League\OAuth2\Server\ResourceServer
+     */
+    private $server;
+
+    /**
+     * Create a new middleware instance.
+     *
+     * @param  \League\OAuth2\Server\ResourceServer  $server
+     * @return void
+     */
+    public function __construct(ResourceServer $server)
+    {
+        $this->server = $server;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  mixed  ...$scopes
+     * @return mixed
+     * @throws \Illuminate\Auth\AuthenticationException
+     */
+    public function handle($request, Closure $next, ...$scopes)
+    {
+        $psr = (new DiactorosFactory)->createRequest($request);
+
+        try {
+            $psr = $this->server->validateAuthenticatedRequest($psr);
+        } catch (OAuthServerException $e) {
+            throw new AuthenticationException;
+        }
+
+        if ($this->validateScopes($psr, $scopes)) {
+            return $next($request);
+        }
+
+        throw new MissingScopeException($scopes);
+    }
+
+    /**
+     * Validate the scopes on the incoming request.
+     *
+     * @param  \Psr\Http\Message\ResponseInterface $psr
+     * @param  array  $scopes
+     * @return bool
+     * @throws \Laravel\Passport\Exceptions\MissingScopeException
+     */
+    protected function validateScopes($psr, $scopes)
+    {
+        if (in_array('*', $tokenScopes = $psr->getAttribute('oauth_scopes'))) {
+            return true;
+        }
+
+        foreach ($scopes as $scope) {
+            if (in_array($scope, $tokenScopes)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
+++ b/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
@@ -69,12 +69,6 @@ class CheckClientCredentialsForAnyScope
             return true;
         }
 
-        foreach ($scopes as $scope) {
-            if (in_array($scope, $tokenScopes)) {
-                return true;
-            }
-        }
-
-        return false;
+        return (bool) array_intersect($scopes, $tokenScopes);
     }
 }

--- a/tests/CheckClientCredentialsForAnyScopeTest.php
+++ b/tests/CheckClientCredentialsForAnyScopeTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use Illuminate\Http\Request;
+use Laravel\Passport\Http\Middleware\CheckClientCredentialsForAnyScope;
+
+class CheckClientCredentialsForAnyScopeTest extends PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        Mockery::close();
+    }
+
+    public function test_request_is_passed_along_if_token_is_valid()
+    {
+        $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
+        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = Mockery::mock());
+        $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
+        $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['*']);
+
+        $middleware = new CheckClientCredentialsForAnyScope($resourceServer);
+
+        $request = Request::create('/');
+        $request->headers->set('Authorization', 'Bearer token');
+
+        $response = $middleware->handle($request, function () {
+            return 'response';
+        });
+
+        $this->assertEquals('response', $response);
+    }
+
+    public function test_request_is_passed_along_if_token_has_any_required_scope()
+    {
+        $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
+        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = Mockery::mock());
+        $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
+        $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['foo', 'bar', 'baz']);
+
+        $middleware = new CheckClientCredentialsForAnyScope($resourceServer);
+
+        $request = Request::create('/');
+        $request->headers->set('Authorization', 'Bearer token');
+
+        $response = $middleware->handle($request, function () {
+            return 'response';
+        }, 'notfoo', 'bar', 'notbaz');
+
+        $this->assertEquals('response', $response);
+    }
+
+    /**
+     * @expectedException Illuminate\Auth\AuthenticationException
+     */
+    public function test_exception_is_thrown_when_oauth_throws_exception()
+    {
+        $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
+        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andThrow(
+            new League\OAuth2\Server\Exception\OAuthServerException('message', 500, 'error type')
+        );
+
+        $middleware = new CheckClientCredentialsForAnyScope($resourceServer);
+
+        $request = Request::create('/');
+        $request->headers->set('Authorization', 'Bearer token');
+
+        $middleware->handle($request, function () {
+            return 'response';
+        });
+    }
+
+    /**
+     * @expectedException \Laravel\Passport\Exceptions\MissingScopeException
+     */
+    public function test_exception_is_thrown_if_token_does_not_have_required_scope()
+    {
+        $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
+        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = Mockery::mock());
+        $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
+        $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['foo', 'bar']);
+
+        $middleware = new CheckClientCredentialsForAnyScope($resourceServer);
+
+        $request = Request::create('/');
+        $request->headers->set('Authorization', 'Bearer token');
+
+        $response = $middleware->handle($request, function () {
+            return 'response';
+        }, 'baz', 'notbar');
+    }
+}


### PR DESCRIPTION
This PR adds a middleware that checks if a token of grant type `client credentials` has any of the given scopes.
The default implementation comes with the following middleware:
- [CheckClientCredentials](https://github.com/leroy-merlin-br/passport/blob/mongolid/src/Http/Middleware/CheckClientCredentials.php)
- [CheckScopes](https://github.com/leroy-merlin-br/passport/blob/mongolid/src/Http/Middleware/CheckScopes.php)
- [CheckForAnyScope](https://github.com/leroy-merlin-br/passport/blob/mongolid/src/Http/Middleware/CheckForAnyScope.php)

This is basically a merge of CheckClientCredentials and CheckForAnyScope