### PR TITLE
Approve authorization request if client is trusted

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Passport;
 
+use Illuminate\Support\Facades\Request;
 use Mongolid\Util\LocalDateTime;
 use MongolidLaravel\MongolidModel as Model;
 
@@ -62,5 +63,14 @@ class Client extends Model
             'created_at' => LocalDateTime::format($this->created_at, 'Y-m-d H:i:s'),
             'updated_at' => LocalDateTime::format($this->updated_at, 'Y-m-d H:i:s'),
         ];
+    }
+
+    /**
+     * A client is considered trusted when its redirect url and the application
+     * have the same domain.
+     */
+    public function isTrusted(): bool
+    {
+        return Request::getHost() === parse_url($this->redirect, PHP_URL_HOST);
     }
 }

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -76,7 +76,7 @@ class AuthorizationController
                 $authRequest->getClient()
             );
 
-            if ($token && $token->scopes === collect($scopes)->pluck('id')->all()) {
+            if ($client->isTrusted() || ($token && $token->scopes === collect($scopes)->pluck('id')->all())) {
                 return $this->approveRequest($authRequest, $user);
             }
 

--- a/tests/AuthorizationControllerTest.php
+++ b/tests/AuthorizationControllerTest.php
@@ -37,9 +37,11 @@ class AuthorizationControllerTest extends PHPUnit_Framework_TestCase
 
         $clientEntity->shouldReceive('getIdentifier')->andReturn(1);
 
-        $response->shouldReceive('view')->once()->andReturnUsing(function ($view, $data) use ($authRequest) {
+        $client = Mockery::mock('Laravel\Passport\Client')->makePartial();
+
+        $response->shouldReceive('view')->once()->andReturnUsing(function ($view, $data) use ($authRequest, $client) {
             $this->assertEquals('passport::authorize', $view);
-            $this->assertEquals('client', $data['client']);
+            $this->assertEquals($client, $data['client']);
             $this->assertEquals('user', $data['user']);
             $this->assertEquals('description', $data['scopes'][0]->description);
 
@@ -47,13 +49,15 @@ class AuthorizationControllerTest extends PHPUnit_Framework_TestCase
         });
 
         $clients = Mockery::mock('Laravel\Passport\ClientRepository');
-        $clients->shouldReceive('find')->with(1)->andReturn('client');
+        $clients->shouldReceive('find')->with(1)->andReturn($client);
 
         $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
-        $tokens->shouldReceive('findValidToken')->with('user', 'client')->andReturnNull();
+        $tokens->shouldReceive('findValidToken')->with('user', $client)->andReturnNull();
 
         $scopeRepository = Mockery::mock('Laravel\Passport\Bridge\ScopeRepository');
         $scopeRepository->shouldReceive('validateClientScopes')->with($scopes, $clientEntity)->andReturn(true);
+
+        $client->shouldReceive('isTrusted')->andReturn(false);
 
         $this->assertEquals('view', $controller->authorize(
             Mockery::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients, $tokens, $scopeRepository
@@ -118,14 +122,61 @@ class AuthorizationControllerTest extends PHPUnit_Framework_TestCase
         $clientEntity->shouldReceive('getIdentifier')->andReturn(1);
 
         $clients = Mockery::mock('Laravel\Passport\ClientRepository');
-        $clients->shouldReceive('find')->with(1)->andReturn('client');
+        $clients->shouldReceive('find')->with(1)->andReturn($client = Mockery::mock('Laravel\Passport\Client')->makePartial());
 
         $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
-        $tokens->shouldReceive('findValidToken')->with($user, 'client')->andReturn($token = Mockery::mock('Laravel\Passport\Token'));
+        $tokens->shouldReceive('findValidToken')->with($user, $client)->andReturn($token = Mockery::mock('Laravel\Passport\Token'));
         $token->shouldReceive('getAttribute')->with('scopes')->andReturn(['scope-1']);
 
         $scopeRepository = Mockery::mock('Laravel\Passport\Bridge\ScopeRepository');
         $scopeRepository->shouldReceive('validateClientScopes')->with($scopes, $clientEntity)->andReturn(true);
+
+        $client->shouldReceive('isTrusted')->andReturn(false);
+
+        $this->assertEquals('approved', $controller->authorize(
+            Mockery::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients, $tokens, $scopeRepository
+        )->getContent());
+    }
+
+    public function test_request_is_approved_if_client_is_trusted()
+    {
+        Laravel\Passport\Passport::tokensCan([
+            'scope-1' => 'description',
+        ]);
+
+        $server = Mockery::mock(AuthorizationServer::class);
+        $response = Mockery::mock(ResponseFactory::class);
+
+        $controller = new Laravel\Passport\Http\Controllers\AuthorizationController($server, $response);
+        $psrResponse = new Zend\Diactoros\Response();
+        $psrResponse->getBody()->write('approved');
+        $server->shouldReceive('validateAuthorizationRequest')->andReturn($authRequest = Mockery::mock('League\OAuth2\Server\RequestTypes\AuthorizationRequest'));
+        $server->shouldReceive('completeAuthorizationRequest')->with($authRequest, Mockery::type('Psr\Http\Message\ResponseInterface'))->andReturn($psrResponse);
+
+        $request = Mockery::mock('Illuminate\Http\Request');
+        $request->shouldReceive('user')->once()->andReturn($user = Mockery::mock());
+        $user->shouldReceive('getKey')->andReturn(1);
+        $request->shouldNotReceive('session');
+
+        $authRequest->shouldReceive('getClient')->andReturn($clientEntity = Mockery::mock(ClientEntityInterface::class));
+        $authRequest->shouldReceive('getScopes')->twice()->andReturn($scopes = [new Laravel\Passport\Bridge\Scope('scope-1')]);
+        $authRequest->shouldReceive('setUser')->once()->andReturnNull();
+        $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(true);
+        $authRequest->shouldReceive('getGrantTypeId')->andReturn('authorization_code');
+
+        $clientEntity->shouldReceive('getIdentifier')->andReturn(1);
+
+        $clients = Mockery::mock('Laravel\Passport\ClientRepository');
+        $clients->shouldReceive('find')->with(1)->andReturn($client = Mockery::mock('Laravel\Passport\Client')->makePartial());
+
+        $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
+        $tokens->shouldReceive('findValidToken')->with($user, $client)->andReturn($token = Mockery::mock('Laravel\Passport\Token'));
+        $token->shouldReceive('getAttribute')->with('scopes')->andReturn(['scope-1']);
+
+        $scopeRepository = Mockery::mock('Laravel\Passport\Bridge\ScopeRepository');
+        $scopeRepository->shouldReceive('validateClientScopes')->with($scopes, $clientEntity)->andReturn(true);
+
+        $client->shouldReceive('isTrusted')->andReturn(true);
 
         $this->assertEquals('approved', $controller->authorize(
             Mockery::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients, $tokens, $scopeRepository


### PR DESCRIPTION
This could be implemented on our application instead, but it is somehow generic.